### PR TITLE
Use greater of `creationTimestamp` and `lastTimestamp` to determine event age

### DIFF
--- a/kubernetes-event-exporter.code-workspace
+++ b/kubernetes-event-exporter.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"go.testFlags": [
+			"-v",
+		],
+	}
+}

--- a/pkg/kube/watcher.go
+++ b/pkg/kube/watcher.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// TODO: use clock.PassiveClock instead of time.Now() for testing
 var startUpTime = time.Now()
 
 type EventHandler func(event *EnhancedEvent)
@@ -67,27 +69,63 @@ func (e *EventWatcher) OnUpdate(oldObj, newObj interface{}) {
 	e.onEvent(event)
 }
 
-// Ignore events older than the maxEventAgeSeconds
+// Ignore events older than the maxEventAgeSeconds.
 func (e *EventWatcher) isEventDiscarded(event *corev1.Event) bool {
-	timestamp := event.LastTimestamp.Time
-	if timestamp.IsZero() {
-		timestamp = event.EventTime.Time
-	}
-	eventAge := time.Since(timestamp)
+	eventAge, timeUsedForAge := getEventAge(event)
 	if eventAge > e.maxEventAgeSeconds {
 		// Log discarded events if they were created after the watcher started
 		// (to suppres warnings from initial synchrnization)
-		if timestamp.After(startUpTime) {
+		if timeUsedForAge.After(startUpTime) {
 			log.Warn().
-				Str("event age", eventAge.String()).
-				Str("event namespace", event.Namespace).
-				Str("event name", event.Name).
-				Msg("Event discarded as being older then maxEventAgeSeconds")
+				Str("eventAge", eventAge.String()).
+				Str("eventNamespace", event.Namespace).
+				Str("eventName", event.Name).
+				Str("eventMessage", event.Message).
+				Str("eventReason", event.Reason).
+				Str("eventSourceComponent", event.Source.Component).
+				Str("eventSourceHost", event.Source.Host).
+				Str("eventFirstTimestamp", event.FirstTimestamp.String()).
+				Str("eventLastTimestamp", event.LastTimestamp.String()).
+				Str("eventCreationTime", event.CreationTimestamp.String()).
+				Str("eventEventTime", event.EventTime.String()).
+				Str("involvedObjectAPIVersion", event.InvolvedObject.APIVersion).
+				Str("involvedObjectKind", event.InvolvedObject.Kind).
+				Str("involvedObjectNamespace", event.InvolvedObject.Namespace).
+				Str("involvedObjectName", event.InvolvedObject.Name).
+				Str("involvedObjectUID", string(event.InvolvedObject.UID)).
+				Msg(fmt.Sprintf("Event discarded as being older than maxEventAgeSeconds: %v", e.maxEventAgeSeconds))
 			e.metricsStore.EventsDiscarded.Inc()
 		}
 		return true
 	}
 	return false
+}
+
+// getEventAge returns the age of the event and the time used for age calculation.
+// The time used for age calculation is the greater of creationTimestamp and
+// lastTimestamp (or eventTime if lastTimestamp is empty and firstTimestamp if eventTime is empty).
+// While based on event aggregation, lastTimestamp should be greater than creationTimestamp,
+// in practice it doesn't always seem to be the case. Hence, we compare and use the
+// greater of the two to ensure that we process the event and don't skip it.
+func getEventAge(event *corev1.Event) (time.Duration, time.Time) {
+	var timeUsedForAgeCalculation time.Time
+
+	eventTimestamp := event.LastTimestamp.Time
+	if event.LastTimestamp.IsZero() {
+		if event.EventTime.IsZero() {
+			eventTimestamp = event.FirstTimestamp.Time
+		} else {
+			eventTimestamp = event.EventTime.Time
+		}
+	}
+
+	if event.CreationTimestamp.Time.After(eventTimestamp) {
+		timeUsedForAgeCalculation = event.CreationTimestamp.Time
+	} else {
+		timeUsedForAgeCalculation = eventTimestamp
+	}
+
+	return time.Since(timeUsedForAgeCalculation), timeUsedForAgeCalculation
 }
 
 func (e *EventWatcher) onEvent(event *corev1.Event) {

--- a/pkg/kube/watcher_test.go
+++ b/pkg/kube/watcher_test.go
@@ -130,13 +130,15 @@ func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndBeforeMaxAge(t *te
 
 	startup := time.Now().Add(-10 * time.Minute)
 	ew.setStartUpTime(startup)
-	// event is 8m after stratup time (2m in max age) -> expect processed
+	// event is 8m after startup time (2m in max age) -> expect processed
 	event1 := corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Time{Time: startup.Add(8 * time.Minute)},
+		},
 		InvolvedObject: corev1.ObjectReference{
 			UID:  "test",
 			Name: "test-1",
 		},
-		LastTimestamp: metav1.Time{Time: startup.Add(8 * time.Minute)},
 	}
 
 	assert.False(t, ew.isEventDiscarded(&event1))
@@ -145,39 +147,6 @@ func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndBeforeMaxAge(t *te
 	assert.Contains(t, output.String(), "test-1")
 	assert.Contains(t, output.String(), "Received event")
 	assert.Equal(t, float64(1), testutil.ToFloat64(metricsStore.EventsProcessed))
-
-	// event is 8m after stratup time (2m in max age) -> expect processed
-	event2 := corev1.Event{
-		InvolvedObject: corev1.ObjectReference{
-			UID:  "test",
-			Name: "test-2",
-		},
-		EventTime: metav1.MicroTime{Time: startup.Add(8 * time.Minute)},
-	}
-
-	assert.False(t, ew.isEventDiscarded(&event2))
-	assert.NotContains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
-	ew.onEvent(&event2)
-	assert.Contains(t, output.String(), "test-2")
-	assert.Contains(t, output.String(), "Received event")
-	assert.Equal(t, float64(2), testutil.ToFloat64(metricsStore.EventsProcessed))
-
-	// event is 8m after stratup time (2m in max age) -> expect processed
-	event3 := corev1.Event{
-		InvolvedObject: corev1.ObjectReference{
-			UID:  "test",
-			Name: "test-3",
-		},
-		LastTimestamp: metav1.Time{Time: startup.Add(8 * time.Minute)},
-		EventTime:     metav1.MicroTime{Time: startup.Add(8 * time.Minute)},
-	}
-
-	assert.False(t, ew.isEventDiscarded(&event3))
-	assert.NotContains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
-	ew.onEvent(&event3)
-	assert.Contains(t, output.String(), "test-3")
-	assert.Contains(t, output.String(), "Received event")
-	assert.Equal(t, float64(3), testutil.ToFloat64(metricsStore.EventsProcessed))
 
 	metrics.DestroyMetricsStore(metricsStore)
 }
@@ -194,40 +163,15 @@ func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndAfterMaxAge(t *tes
 	startup := time.Now().Add(-10 * time.Minute)
 	ew.setStartUpTime(startup)
 	event1 := corev1.Event{
-		ObjectMeta:    metav1.ObjectMeta{Name: "event1"},
-		LastTimestamp: metav1.Time{Time: startup.Add(3 * time.Minute)},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "event1",
+			CreationTimestamp: metav1.Time{Time: startup.Add(3 * time.Minute)},
+		},
 	}
 	assert.True(t, ew.isEventDiscarded(&event1))
 	assert.Contains(t, output.String(), "event1")
-	assert.Contains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
+	assert.Contains(t, output.String(), "Event discarded as being older than maxEventAgeSeconds")
 	ew.onEvent(&event1)
-	assert.NotContains(t, output.String(), "Received event")
-	assert.Equal(t, float64(0), testutil.ToFloat64(metricsStore.EventsProcessed))
-
-	// event is 3m after stratup time (and 2m after max age) -> expect dropped with warn
-	event2 := corev1.Event{
-		ObjectMeta: metav1.ObjectMeta{Name: "event2"},
-		EventTime:  metav1.MicroTime{Time: startup.Add(3 * time.Minute)},
-	}
-
-	assert.True(t, ew.isEventDiscarded(&event2))
-	assert.Contains(t, output.String(), "event2")
-	assert.Contains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
-	ew.onEvent(&event2)
-	assert.NotContains(t, output.String(), "Received event")
-	assert.Equal(t, float64(0), testutil.ToFloat64(metricsStore.EventsProcessed))
-
-	// event is 3m after stratup time (and 2m after max age) -> expect dropped with warn
-	event3 := corev1.Event{
-		ObjectMeta:    metav1.ObjectMeta{Name: "event3"},
-		LastTimestamp: metav1.Time{Time: startup.Add(3 * time.Minute)},
-		EventTime:     metav1.MicroTime{Time: startup.Add(3 * time.Minute)},
-	}
-
-	assert.True(t, ew.isEventDiscarded(&event3))
-	assert.Contains(t, output.String(), "event3")
-	assert.Contains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
-	ew.onEvent(&event3)
 	assert.NotContains(t, output.String(), "Received event")
 	assert.Equal(t, float64(0), testutil.ToFloat64(metricsStore.EventsProcessed))
 
@@ -247,8 +191,10 @@ func TestOnEvent_WithObjectMetadata(t *testing.T) {
 	startup := time.Now().Add(-10 * time.Minute)
 	ew.setStartUpTime(startup)
 	event1 := corev1.Event{
-		ObjectMeta:    metav1.ObjectMeta{Name: "event1"},
-		LastTimestamp: metav1.Time{Time: startup.Add(8 * time.Minute)},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "event1",
+			CreationTimestamp: metav1.Time{Time: startup.Add(8 * time.Minute)},
+		},
 		InvolvedObject: corev1.ObjectReference{
 			UID:  "test",
 			Name: "test-1",
@@ -284,8 +230,10 @@ func TestOnEvent_DeletedObjects(t *testing.T) {
 	startup := time.Now().Add(-10 * time.Minute)
 	ew.setStartUpTime(startup)
 	event1 := corev1.Event{
-		ObjectMeta:    metav1.ObjectMeta{Name: "event1"},
-		LastTimestamp: metav1.Time{Time: startup.Add(8 * time.Minute)},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "event1",
+			CreationTimestamp: metav1.Time{Time: startup.Add(8 * time.Minute)},
+		},
 		InvolvedObject: corev1.ObjectReference{
 			UID:  "test",
 			Name: "test-1",

--- a/pkg/kube/watcher_test.go
+++ b/pkg/kube/watcher_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	testclock "k8s.io/utils/clock/testing"
 )
 
 type mockObjectMetadataProvider struct {
@@ -130,23 +131,47 @@ func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndBeforeMaxAge(t *te
 
 	startup := time.Now().Add(-10 * time.Minute)
 	ew.setStartUpTime(startup)
-	// event is 8m after startup time (2m in max age) -> expect processed
-	event1 := corev1.Event{
-		ObjectMeta: metav1.ObjectMeta{
-			CreationTimestamp: metav1.Time{Time: startup.Add(8 * time.Minute)},
-		},
-		InvolvedObject: corev1.ObjectReference{
-			UID:  "test",
-			Name: "test-1",
-		},
-	}
 
-	assert.False(t, ew.isEventDiscarded(&event1))
-	assert.NotContains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
-	ew.onEvent(&event1)
-	assert.Contains(t, output.String(), "test-1")
-	assert.Contains(t, output.String(), "Received event")
-	assert.Equal(t, float64(1), testutil.ToFloat64(metricsStore.EventsProcessed))
+	t.Run("last timetamp is empty", func(t *testing.T) {
+		// creation time is 8m after startup time (2m in max age) -> expect processed
+		event := corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{Time: startup.Add(8 * time.Minute)},
+			},
+			InvolvedObject: corev1.ObjectReference{
+				UID:  "test",
+				Name: "test-1",
+			},
+		}
+
+		assert.False(t, ew.isEventDiscarded(&event))
+		assert.NotContains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
+		ew.onEvent(&event)
+		assert.Contains(t, output.String(), "test-1")
+		assert.Contains(t, output.String(), "Received event")
+		assert.Equal(t, float64(1), testutil.ToFloat64(metricsStore.EventsProcessed))
+	})
+
+	t.Run("last timetamp is after creation timestamp", func(t *testing.T) {
+		// event is 8m after stratup time (2m after max age) -> expect processed
+		event := corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{Time: startup},
+			},
+			LastTimestamp: metav1.Time{Time: startup.Add(9 * time.Minute)},
+			InvolvedObject: corev1.ObjectReference{
+				UID:  "test",
+				Name: "test-2",
+			},
+		}
+
+		assert.False(t, ew.isEventDiscarded(&event))
+		assert.NotContains(t, output.String(), "Event discarded as being older then maxEventAgeSeconds")
+		ew.onEvent(&event)
+		assert.Contains(t, output.String(), "test-2")
+		assert.Contains(t, output.String(), "Received event")
+		assert.Equal(t, float64(2), testutil.ToFloat64(metricsStore.EventsProcessed))
+	})
 
 	metrics.DestroyMetricsStore(metricsStore)
 }
@@ -162,18 +187,37 @@ func TestEventWatcher_EventAge_whenEventCreatedAfterStartupAndAfterMaxAge(t *tes
 	// event is 3m after stratup time (and 2m after max age) -> expect dropped with warn
 	startup := time.Now().Add(-10 * time.Minute)
 	ew.setStartUpTime(startup)
-	event1 := corev1.Event{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "event1",
-			CreationTimestamp: metav1.Time{Time: startup.Add(3 * time.Minute)},
-		},
-	}
-	assert.True(t, ew.isEventDiscarded(&event1))
-	assert.Contains(t, output.String(), "event1")
-	assert.Contains(t, output.String(), "Event discarded as being older than maxEventAgeSeconds")
-	ew.onEvent(&event1)
-	assert.NotContains(t, output.String(), "Received event")
-	assert.Equal(t, float64(0), testutil.ToFloat64(metricsStore.EventsProcessed))
+
+	t.Run("last timestamp is empty", func(t *testing.T) {
+		event := corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "event1",
+				CreationTimestamp: metav1.Time{Time: startup.Add(3 * time.Minute)},
+			},
+		}
+		assert.True(t, ew.isEventDiscarded(&event))
+		assert.Contains(t, output.String(), "event1")
+		assert.Contains(t, output.String(), "Event discarded as being older than maxEventAgeSeconds")
+		ew.onEvent(&event)
+		assert.NotContains(t, output.String(), "Received event")
+		assert.Equal(t, float64(0), testutil.ToFloat64(metricsStore.EventsProcessed))
+	})
+
+	t.Run("last timestamp is after creation timestamp", func(t *testing.T) {
+		event := corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "event2",
+				CreationTimestamp: metav1.Time{Time: startup.Add(3 * time.Minute)},
+			},
+			LastTimestamp: metav1.Time{Time: startup.Add(4 * time.Minute)},
+		}
+		assert.True(t, ew.isEventDiscarded(&event))
+		assert.Contains(t, output.String(), "event2")
+		assert.Contains(t, output.String(), "Event discarded as being older than maxEventAgeSeconds")
+		ew.onEvent(&event)
+		assert.NotContains(t, output.String(), "Received event")
+		assert.Equal(t, float64(0), testutil.ToFloat64(metricsStore.EventsProcessed))
+	})
 
 	metrics.DestroyMetricsStore(metricsStore)
 }
@@ -248,4 +292,52 @@ func TestOnEvent_DeletedObjects(t *testing.T) {
 	require.Equal(t, map[string]string(nil), event.InvolvedObject.Annotations)
 	require.Equal(t, map[string]string(nil), event.InvolvedObject.Labels)
 	require.Equal(t, []metav1.OwnerReference(nil), event.InvolvedObject.OwnerReferences)
+}
+
+func TestGetEventAge(t *testing.T) {
+	testTime := time.Date(2024, 1, 2, 3, 4, 5, 6, time.UTC)
+	fakeClock := testclock.NewFakePassiveClock(testTime)
+	testCases := map[string]struct {
+		event                             corev1.Event
+		expectedTimeUsedForAgeCalculation time.Time
+		expectedAge                       time.Duration
+	}{
+		"last timestamp is after creation timestamp": {
+			event: corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Time{Time: testTime.Add(-5 * time.Minute)},
+				},
+				LastTimestamp: metav1.Time{Time: testTime.Add(-3 * time.Minute)},
+			},
+			expectedTimeUsedForAgeCalculation: testTime.Add(-3 * time.Minute),
+			expectedAge:                       3 * time.Minute,
+		},
+		"creation timestamp is after last timestamp": {
+			event: corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Time{Time: testTime.Add(-2 * time.Minute)},
+				},
+				LastTimestamp: metav1.Time{Time: testTime.Add(-4 * time.Minute)},
+			},
+			expectedTimeUsedForAgeCalculation: testTime.Add(-2 * time.Minute),
+			expectedAge:                       2 * time.Minute,
+		},
+		"last timestamp is empty": {
+			event: corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Time{Time: testTime},
+				},
+			},
+			expectedTimeUsedForAgeCalculation: testTime,
+			expectedAge:                       0,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			age, timeUsedForAgeCalculation := getEventAge(&tc.event, fakeClock)
+			require.Equal(t, tc.expectedAge, age)
+			require.Equal(t, tc.expectedTimeUsedForAgeCalculation, timeUsedForAgeCalculation)
+		})
+	}
 }


### PR DESCRIPTION
Currently, kubernetes-events-exporter looks at lastTimestamp (eventTime if lastTimestamp is missing)
of the event to determine the event age. If event age exceeded maxEventAgeSeconds, the event
is discarded. While based on event aggregation, lastTimestamp should be greater than creationTimestamp,
in practice it doesn't always seem to be the case. Hence, the current way of determining eventAge
sometimes results in events younger than maxEventAgeSeconds not getting processed. So as part of this
change, we use the greater of creationTimestamp and lastTimestamp to calculate event age. This allows us to capture more events rather than less and even if an event is processed more than once, we can de-dup it during
analysis by using a distinct operation on ResourceVersion.

**How event aggregation works at a high level**
At a high level, client-go maintains a local events cache. When a new event comes, it correlates
this event with the ones in cache. If it finds a matching event in the cache, it just updates the
event count and the message (prefixes message with "(combined from similar events) $original-message")
and patches the existing event instead of creating a new one. This is an optimization to reduce the
storage needed to persist events in ETCD. Additionally, events have a TTL set (defaults to 1hr). So,
if client-go tries to patch an event and the event has already expired, it creates a new event in this
case. In such scenarios, the lastTimestamp of the event is kept from what was in the cache and the
creationTimestamp is set by the apiserver when the event is created. While technically the delta between
lastTimestamp and creationTimestamp should be very small, in practice, the delta is seen up to a few minutes.
We haven't exactly found why that is the case but a probable reason is that before the event is created, the
request to apiserver is queued.

References:
* Here's an explanation of how event aggregation works - https://dev.to/shuheiktgw/kubernetes-event-aggregation-and-spam-filtering-in-client-go-25mn
* Event aggregation: https://github.com/kubernetes/kubernetes/blob/d9c7616d4b2f563c055df1f378d4dbeed33af869/staging/src/k8s.io/client-go/tools/record/events_cache.go#L242
* Event update: https://github.com/kubernetes/kubernetes/blob/d9c7616d4b2f563c055df1f378d4dbeed33af869/staging/src/k8s.io/client-go/tools/record/events_cache.go#L327