### PR TITLE
Add clusterEnvironment field in enhanced event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 .DS_Store
 /kubernetes-event-exporter
+
+*.code-workspace

--- a/main.go
+++ b/main.go
@@ -82,11 +82,16 @@ func main() {
 
 	engine := exporter.NewEngine(&cfg, &exporter.ChannelBasedReceiverRegistry{MetricsStore: metricsStore})
 	onEvent := engine.OnEvent
-	if len(cfg.ClusterName) != 0 {
+	if cfg.ClusterEnvironment != "" || cfg.ClusterName != "" {
+		log.Info().Msgf("ClusterName: %s, ClusterEnvironment: %s", cfg.ClusterName, cfg.ClusterEnvironment)
+
 		onEvent = func(event *kube.EnhancedEvent) {
-			// note that per code this value is not set anywhere on the kubernetes side
-			// https://github.com/kubernetes/apimachinery/blob/v0.22.4/pkg/apis/meta/v1/types.go#L276
-			event.ClusterName = cfg.ClusterName
+			if cfg.ClusterEnvironment != "" {
+				event.ClusterEnvironment = cfg.ClusterEnvironment
+			}
+			if cfg.ClusterName != "" {
+				event.ClusterName = cfg.ClusterName
+			}
 			engine.OnEvent(event)
 		}
 	}

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	MetricsNamePrefix  string                    `yaml:"metricsNamePrefix,omitempty"`
 	OmitLookup         bool                      `yaml:"omitLookup,omitempty"`
 	CacheSize          int                       `yaml:"cacheSize,omitempty"`
+	ClusterEnvironment string                    `yaml:"clusterEnvironment,omitempty"`
 }
 
 func (c *Config) SetDefaults() {

--- a/pkg/kube/event.go
+++ b/pkg/kube/event.go
@@ -10,9 +10,10 @@ import (
 )
 
 type EnhancedEvent struct {
-	corev1.Event   `json:",inline"`
-	ClusterName    string                  `json:"clusterName"`
-	InvolvedObject EnhancedObjectReference `json:"involvedObject"`
+	corev1.Event       `json:",inline"`
+	ClusterName        string                  `json:"clusterName,omitempty"`
+	ClusterEnvironment string                  `json:"clusterEnvironment,omitempty"`
+	InvolvedObject     EnhancedObjectReference `json:"involvedObject"`
 }
 
 // DeDot replaces all dots in the labels and annotations with underscores. This is required for example in the


### PR DESCRIPTION
## Summary
Porting over this change to the LinkedIn fork: https://github.com/ronaknnathani/kubernetes-event-exporter/pull/2. This change wasn't merged upstream and hence the LinkedIn fork doesn't have it.

Original commit message:
Many teams who run multiple clusters across different environments and send events to a centralized logging backend, can use a field like clusterEnvironment to create dashboards with filters so that easily look at events from different environments.

Additionally, this change makes clusterName and clusterEnviroment optional in the output if they are not set.

## Testing done
As mentioned in https://github.com/ronaknnathani/kubernetes-event-exporter/pull/2.