### PR TITLE
Update github actions for test and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,47 +1,34 @@
-name: Publish Docker image
+# Ref: https://goreleaser.com/ci/actions/
 
+name: goreleaser
 on:
-  release:
-    types: [published]
-
+  push:
+    # run only against tags
+    tags:
+      - "v*.*.*"
+permissions:
+  # needed to create releases
+  contents: write
 jobs:
-  push_to_registries:
-    name: Push Docker image to multiple registries
+  goreleaser:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.20'
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v5
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release --clean
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,22 +1,23 @@
-name: Test
-on: [push, pull_request]
+name: build_and_test
+on:
+  push:
+  pull_request:
 jobs:
-  build:
-    name: Build
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
-
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v3
+    - name: Checkout
+      uses: actions/checkout@v4
       with:
-        go-version: "1.20"
-      id: go
+        fetch-depth: 0
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+    - name: Setup Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.20'
 
-    - name: Build
-      run: go build -v .
-    
-    - name: Test
-      run:  go test ./...
+    - name: GoReleaser
+      uses: goreleaser/goreleaser-action@v5
+      with:
+        version: latest
+        args: release --snapshot --clean

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /kubernetes-event-exporter
 
 *.code-workspace
+
+dist/*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,31 @@
+# Ref https://goreleaser.com
+
+version: 1
+
+before:
+  hooks:
+    - go mod tidy
+    - go vet ./...
+    - go test -mod=mod -v ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_{{- .Os }}_{{ .Tag }}_{{ .Arch }}{{- if .Arm }}v{{ .Arm }}{{ end }}
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"


### PR DESCRIPTION
## Summary
Everytime we want to release a new version of `kubernetes-event-exporter`, we need to build the binaries to be deployed. This change updates the existing GitHub actions to use https://goreleaser.com/ci/actions/ to
1. build/test when code is pushed or a PR is created
2. create a release with binaries when a new tag is pushed